### PR TITLE
HYDRAN-2676: speed up garbage schedule SFTP download and instrument transfer

### DIFF
--- a/src/main/java/se/sundsvall/garbage/integration/filehandler/FileHandler.java
+++ b/src/main/java/se/sundsvall/garbage/integration/filehandler/FileHandler.java
@@ -1,6 +1,9 @@
 package se.sundsvall.garbage.integration.filehandler;
 
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
 import java.io.FileReader;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -10,9 +13,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
-import org.apache.commons.vfs2.FileSystemException;
-import org.apache.commons.vfs2.Selectors;
+import org.apache.commons.vfs2.FileSystemOptions;
 import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -33,6 +36,11 @@ public class FileHandler {
 
 	private static final String TEMP_FILE = System.getProperty("java.io.tmpdir") + "/schedule.csv";
 
+	// The commons-vfs2/JSch SFTP input stream turns each read into a synchronous request→response, so
+	// a small buffer means thousands of round-trips. Over a high-latency path that collapses throughput
+	// (an 8 MB file took ~10 min in production). A 64 KB buffer cuts the round-trip count dramatically.
+	private static final int DOWNLOAD_BUFFER_SIZE = 64 * 1024;
+
 	private static final Logger log = LoggerFactory.getLogger(FileHandler.class);
 
 	private static final DateTimeFormatter PICKUP_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
@@ -49,19 +57,38 @@ public class FileHandler {
 	 * Downloads the garbage schedule CSV file from the configured SFTP server to a local temporary file.
 	 */
 	public void downloadFile() {
+		final var start = System.nanoTime();
 		try {
 			final var manager = VFS.getManager();
+
+			// Bound the transfer so a stalled connection fails fast instead of hanging the whole
+			// scheduled job. connectTimeout caps the TCP/SSH handshake; sessionTimeout is the socket
+			// read timeout, so a mid-transfer stall (no bytes for that long) aborts rather than idling.
+			final var options = new FileSystemOptions();
+			final var builder = SftpFileSystemConfigBuilder.getInstance();
+			Optional.ofNullable(sftpProperties.connectTimeout()).ifPresent(timeout -> builder.setConnectTimeout(options, timeout));
+			Optional.ofNullable(sftpProperties.sessionTimeout()).ifPresent(timeout -> builder.setSessionTimeout(options, timeout));
+
 			final var local = manager.resolveFile(TEMP_FILE);
 			final var remote = manager.resolveFile(String.format("sftp://%s:%s@%s/%s",
 				sftpProperties.username(),
 				sftpProperties.password(),
 				sftpProperties.remoteHost(),
-				sftpProperties.filename()));
-			local.copyFrom(remote, Selectors.SELECT_SELF);
-			local.close();
-			remote.close();
-		} catch (final FileSystemException e) {
-			log.info("Something went wrong downloading file", e);
+				sftpProperties.filename()), options);
+			try {
+				// Stream through a large buffer rather than copyFrom's default: buffering forces the SFTP
+				// channel to serve large reads, so an 8 MB file is ~128 round-trips instead of ~1000+.
+				try (final var in = new BufferedInputStream(remote.getContent().getInputStream(), DOWNLOAD_BUFFER_SIZE);
+					final var out = new BufferedOutputStream(local.getContent().getOutputStream(), DOWNLOAD_BUFFER_SIZE)) {
+					in.transferTo(out);
+				}
+			} finally {
+				local.close();
+				remote.close();
+			}
+			log.info("Downloaded schedule file ({} bytes) in {} ms", fileSize(), elapsedMs(start));
+		} catch (final IOException e) {
+			log.info("Something went wrong downloading file (after {} ms)", elapsedMs(start), e);
 		}
 	}
 
@@ -72,6 +99,7 @@ public class FileHandler {
 	 * @return a list of parsed entities, or an empty list on error
 	 */
 	public List<GarbageScheduleEntity> parseFile() {
+		final var start = System.nanoTime();
 		final var csvMapper = new CsvMapper();
 		final var schema = buildSchema();
 
@@ -83,10 +111,23 @@ public class FileHandler {
 				.toList();
 
 			Files.delete(Path.of(TEMP_FILE));
+			log.info("Parsed {} rows from schedule file in {} ms", result.size(), elapsedMs(start));
 			return result;
 		} catch (final Exception e) {
-			log.info("Something went wrong parsing file", e);
+			log.info("Something went wrong parsing file (after {} ms)", elapsedMs(start), e);
 			return Collections.emptyList();
+		}
+	}
+
+	private static long elapsedMs(final long startNanos) {
+		return (System.nanoTime() - startNanos) / 1_000_000;
+	}
+
+	private static long fileSize() {
+		try {
+			return Files.size(Path.of(TEMP_FILE));
+		} catch (final IOException e) {
+			return -1;
 		}
 	}
 

--- a/src/main/java/se/sundsvall/garbage/integration/filehandler/SftpProperties.java
+++ b/src/main/java/se/sundsvall/garbage/integration/filehandler/SftpProperties.java
@@ -1,8 +1,9 @@
 package se.sundsvall.garbage.integration.filehandler;
 
+import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("integration.sftp")
-public record SftpProperties(String username, String password, String remoteHost, String filename) {
+public record SftpProperties(String username, String password, String remoteHost, String filename, Duration connectTimeout, Duration sessionTimeout) {
 
 }

--- a/src/main/resources/application-it.yml
+++ b/src/main/resources/application-it.yml
@@ -28,3 +28,5 @@ integration:
     password: password
     remote-host: localhost
     filename: schedule2.csv
+    connect-timeout: PT30S
+    session-timeout: PT30S

--- a/src/main/resources/application-junit.yml
+++ b/src/main/resources/application-junit.yml
@@ -28,3 +28,5 @@ integration:
     password: password
     remote-host: localhost
     filename: schedule.csv
+    connect-timeout: PT30S
+    session-timeout: PT30S

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,13 @@ spring:
     hikari:
       pool-name: garbage-pool
     type: com.zaxxer.hikari.HikariDataSource
+integration:
+  sftp:
+    # Credentials (username/password/remote-host/filename) are injected via environment in each
+    # deployment. connect-timeout bounds the handshake; session-timeout is the socket read timeout,
+    # so a stalled transfer aborts quickly instead of hanging the scheduled job.
+    connect-timeout: PT30S
+    session-timeout: PT30S
 schedulers:
   update-garbage-schedules:
     municipality-ids: 2281


### PR DESCRIPTION
## Problem

The nightly `updateGarbageSchedules` job was timing out after ~10 minutes and then failing on a dead DB connection (`Connection reset by peer` on `select count(*) from garbageschedule`). Manually fetching the schedule file showed **8 MB transferred in ~1 second** — so the file and SFTP server are fine. The bottleneck was the download *mechanism*: `commons-vfs2` + JSch turns each SFTP read into a synchronous request→response, so over the pod's network path throughput collapsed to ~13 KB/s and the transfer ran for ~10 minutes. During that window no DB activity happened, so the pooled connection was reaped and the first query (`count()`) hit a dead socket.

## Changes

- **Buffered streaming download** — replace `copyFrom` with a 64 KB buffered `transferTo`, cutting SFTP round-trips from ~1000+ to ~128 for an 8 MB file.
- **SFTP connect/session timeouts** (`PT30S`) — a stalled transfer now fails fast instead of hanging the scheduled job up to its execution limit.
- **Per-phase instrumentation** — log elapsed ms + byte count for the download and elapsed ms + row count for the parse, so the next run shows exactly where time goes.

## Testing

- `mvn verify` green: 56 unit + 4 integration tests, 0 failures; JaCoCo 85% gate passed.

## Follow-ups (not in this PR)

- DB connection keepalive (`spring.datasource.hikari.keepalive-time` / `max-lifetime`) as defense against idle-connection reaping — pending confirmation of the real MariaDB/proxy idle timeout.
- Move the SFTP download/parse out of the `@Transactional` boundary so a DB connection is never held across the I/O.