### PR TITLE
HYDRAN-2677: stop reusing cached SFTP session between schedule downloads

### DIFF
--- a/src/main/java/se/sundsvall/garbage/integration/filehandler/FileHandler.java
+++ b/src/main/java/se/sundsvall/garbage/integration/filehandler/FileHandler.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.apache.commons.vfs2.FileSystemOptions;
-import org.apache.commons.vfs2.VFS;
+import org.apache.commons.vfs2.impl.StandardFileSystemManager;
 import org.apache.commons.vfs2.provider.sftp.SftpFileSystemConfigBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,8 +58,16 @@ public class FileHandler {
 	 */
 	public void downloadFile() {
 		final var start = System.nanoTime();
+
+		// Use a private manager rather than the process-wide VFS.getManager() singleton, and close it
+		// when done. The shared manager caches the SftpFileSystem — session and channel — indefinitely,
+		// and SftpFileSystem.getChannel() hands back its cached idleChannel WITHOUT revalidating the
+		// session. Since sessionTimeout closes the idle session shortly after a run, the next run would
+		// otherwise pick up a dead channel and fail with "Pipe closed". Owning the manager keeps the
+		// session alive only for the duration of the transfer, so nothing stale can be cached or shared.
+		final var manager = new StandardFileSystemManager();
 		try {
-			final var manager = VFS.getManager();
+			manager.init();
 
 			// Bound the transfer so a stalled connection fails fast instead of hanging the whole
 			// scheduled job. connectTimeout caps the TCP/SSH handshake; sessionTimeout is the socket
@@ -88,7 +96,11 @@ public class FileHandler {
 			}
 			log.info("Downloaded schedule file ({} bytes) in {} ms", fileSize(), elapsedMs(start));
 		} catch (final IOException e) {
-			log.info("Something went wrong downloading file (after {} ms)", elapsedMs(start), e);
+			// Fail loudly: a swallowed download failure lets parseFile() run against a missing or stale
+			// temp file, which surfaces as the misleading "Schedule file did not contain any rows".
+			throw new IllegalStateException("Failed to download garbage schedule file from SFTP after " + elapsedMs(start) + " ms", e);
+		} finally {
+			manager.close();
 		}
 	}
 

--- a/src/test/java/se/sundsvall/garbage/integration/filehandler/FileHandlerTest.java
+++ b/src/test/java/se/sundsvall/garbage/integration/filehandler/FileHandlerTest.java
@@ -16,6 +16,7 @@ import se.sundsvall.garbage.api.model.enums.FacilityCategory;
 import se.sundsvall.garbage.api.model.enums.WasteType;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -29,12 +30,16 @@ class FileHandlerTest {
 	private FileHandler fileHandler;
 
 	@Test
-	void downloadFile() {
+	void downloadFileWhenRemoteUnreachable() {
 		when(sftpProperties.username()).thenReturn("username");
 		when(sftpProperties.password()).thenReturn("password");
 		when(sftpProperties.remoteHost()).thenReturn("remoteHost");
 
-		fileHandler.downloadFile();
+		// A download failure must propagate rather than be swallowed, otherwise parseFile() runs against
+		// a missing temp file and the job reports "did not contain any rows" instead of the real cause.
+		assertThatThrownBy(() -> fileHandler.downloadFile())
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("Failed to download garbage schedule file from SFTP");
 
 		verify(sftpProperties).username();
 		verify(sftpProperties).password();


### PR DESCRIPTION
## Problem

Since #118 deployed, `updateGarbageSchedules` fails at the download with `Pipe closed` out of `ChannelSftp.get()` — before a single byte moves — and then reports the misleading health message **"Schedule file did not contain any rows"**.

**No data was lost:** the `entities.isEmpty()` guard in `performUpdate` meant `deleteAllInBatch()` never ran, so the existing 82,580 rows stayed intact.

## Root cause

Two things combine:

1. **`VFS.getManager()` is a process-wide singleton** that caches the `SftpFileSystem` — session *and* channel — indefinitely, across runs.
2. **`SftpFileSystem.getChannel()` (commons-vfs2 2.10.0) returns its cached `idleChannel` without calling `getSession()`** — the session-liveness check only runs when the cache is empty, so a dead channel is handed straight back.

Before #118 no `sessionTimeout` was set, so JSch's socket had no `SO_TIMEOUT`, the cached session stayed nominally alive, and the reuse happened to work. #118 added `session-timeout: PT30S`, so the idle session now dies ~30s after each run and poisons that cache.

This matches the timeline exactly: **07-14 was the first run after deploy** (clean cache → downloaded 8 MB in 603 ms ✓); **07-16 was the next run** (poisoned cache → `Pipe closed` ✓).

The timeout itself is correct — caching a session *between* runs is what's wrong.

## Changes

- **Private `StandardFileSystemManager` per download**, closed in a `finally`. The session now lives only for the duration of the transfer, so nothing stale can be cached and concurrent runs can't share a channel. `PT30S` stays and now only ever applies during an active transfer, which is what it was for.
- **Throw on download failure instead of swallowing.** The swallow is what produced the misleading health message: the download died, `parseFile()` then ran against a missing `/tmp/schedule.csv`, returned empty, and hit the isEmpty branch. It now reports "Could not complete update of garbage schedules" with the real cause attached.

## Testing

- `mvn verify` green: 56 unit + 4 integration tests, 0 failures.
- `FileHandlerTest.downloadFile` renamed to `downloadFileWhenRemoteUnreachable` and now asserts the throw.

## Note for the reviewer

The fresh SSH handshake in the failing log means I can't claim certainty about the exact interleaving inside VFS — a stale channel taken straight from the cache wouldn't produce a handshake. The reconstruction above fits all the evidence, but the fix's value doesn't depend on it: removing cross-run cached session state eliminates this failure class regardless. It's also verifiable — every run should now show its own handshake.

## Follow-ups (not in this PR)

- The scheduler and the `@Async` trigger both write the same hardcoded `/tmp/schedule.csv`; concurrent runs would corrupt each other.
- DB connection keepalive (`hikari.keepalive-time` / `max-lifetime`), still pending the real MariaDB/proxy idle timeout.
- Move the SFTP I/O out of the `@Transactional` boundary.